### PR TITLE
display all fruit when "all" filter selected

### DIFF
--- a/src/components/FilteredFruitList.js
+++ b/src/components/FilteredFruitList.js
@@ -16,7 +16,7 @@ class FilteredFruitList extends Component {
   }
 
   render() {
-    const list = !this.props.filter ? this.state.items : this.state.items.filter(i => i.fruit_type === this.props.filter);
+    const list = !this.props.filter || this.props.filter === 'all' ? this.state.items : this.state.items.filter(i => i.fruit_type === this.props.filter);
 
     return (
       <ul className="fruit-list">


### PR DESCRIPTION
Displays the entire list of fruit both when there is no filter **and** when the 'all' filter is selected.

fixes #11 

This issue can also be fixed by adding some logic to the filter selection callback, to have it set the filter to `null` if `'all'` is selected, but this felt simpler.